### PR TITLE
added responsive menu to the application

### DIFF
--- a/src/components/DashboardHeader.vue
+++ b/src/components/DashboardHeader.vue
@@ -1,6 +1,12 @@
 <template>
-  <q-toolbar class="q-pa-none">
-    <q-toolbar-title class="header">
+  <q-toolbar class="q-pa-none header">
+    <q-img
+      src="../assets/icons/ALGOP.svg"
+      class="btn-drawer q-ml-lg"
+      :class="[leftDrawerOpen ? 'hide' : 'show']"
+      @click="moveDrawer"
+    />
+    <q-toolbar-title class="title">
       {{ $route.meta.title }}
     </q-toolbar-title>
     <nav class="q-pr-lg nav-bar text-primary">
@@ -15,29 +21,72 @@
 </template>
 
 <script lang="ts">
-import { Options, Vue } from 'vue-class-component';
+import { Options, Vue, prop } from 'vue-class-component';
 import AlgoButton from 'components/common/Button.vue';
 
+class Props {
+  leftDrawerOpen = prop({
+    type: Boolean,
+  });
+}
+
 @Options({
-  emits: ['connectYourWalletClicked'],
+  emits: ['connectYourWalletClicked', 'openDrawer'],
   components: {
     AlgoButton,
   },
+  /* watch: {
+    leftDrawerOpen = 
+  }, */
 })
-export default class DashboardHeader extends Vue {
+export default class DashboardHeader extends Vue.with(Props) {
+  windowSize = window.innerWidth;
+
   connectYourWalletClicked() {
     this.$emit('connectYourWalletClicked');
+  }
+
+  moveDrawer() {
+    console.log(this.leftDrawerOpen);
+    this.$emit('openDrawer');
   }
 }
 </script>
 
 <style lang="scss" scoped>
+.header {
+  .btn-drawer {
+    width: 57.6px;
+  }
+  .hide {
+    display: none;
+  }
+  .show {
+    display: inline-block;
+  }
+}
 .nav-bar {
   display: flex;
 
   .item {
     padding: 0 24px;
     cursor: pointer;
+  }
+}
+
+@media(max-width: 450px) {
+  .header {
+    display: flex;
+    justify-content: space-between;
+    .btn-drawer {
+      margin-left: 20px;
+    }
+    .title {
+      display: none;
+    }
+    .nav {
+
+    }
   }
 }
 </style>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,17 +1,25 @@
 <template>
   <q-layout view="lHh Lpr lFf">
     <q-header class="q-py-lg bg-white">
-      <dashboard-header @connectYourWalletClicked="refreshModal" />
+      <dashboard-header
+        :leftDrawerOpen="leftDrawerOpen"
+        @connectYourWalletClicked="refreshModal"
+        @openDrawer="openDrawer"
+      />
     </q-header>
     <q-drawer
       v-model="leftDrawerOpen"
       :width="120"
+      :breakpoint="768"
     >
       <side-bar />
     </q-drawer>
     <q-page-container class="q-px-lg">
       <router-view />
-      <connect-your-wallet v-if="showModal" @connected="refreshModal" />
+      <connect-your-wallet
+        v-if="showModal"
+        @connected="refreshModal"
+      />
     </q-page-container>
   </q-layout>
 </template>
@@ -31,9 +39,23 @@ import ConnectYourWallet from 'components/common/ConnectYourWallet.vue';
   },
 })
 export default class MainLayout extends Vue {
-  leftDrawerOpen = true;
+  leftDrawerOpen: boolean = false;
+
+  beforeMount() {
+    if (window.innerWidth <= 768) {
+      this.leftDrawerOpen = false;
+    } else {
+      this.leftDrawerOpen = true;
+      // enquanto leftDrawerOpen for true, quero o display do button como hidden
+    }
+  }
 
   showModal: boolean = false;
+
+  openDrawer() {
+    // console.log(this.leftDrawerOpen);
+    this.leftDrawerOpen = true;
+  }
 
   isConnected() {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access


### PR DESCRIPTION
- Quasar has a built-in layout structure that is composed by header, footer and left and right drawers. We don't make use of the footer and right drawer in our application but we do use the left-drawer as our main navigator. Since our menu doesn't come from the header, but from the left drawer, and the left drawer can only be pulled back to the left side of the screen, this was the best way I found to make the website responsive on smaller screens that would not demand a website restructuration.